### PR TITLE
Remove unnecessary "WORKSPACE" env var

### DIFF
--- a/vars/wrappedNode.groovy
+++ b/vars/wrappedNode.groovy
@@ -1,21 +1,19 @@
 def call(Map vars, Closure body=null) {
   vars = vars ?: [:]
   node(vars.get("label", null)) {
-    withEnv(["WORKSPACE=${sh(script: 'pwd', returnStdout: true).trim()}"]) {
-      withDockerRegistry(url: vars.get("registryUrl", "https://index.docker.io/v1/"), credentialsId: vars.get("registryCreds", "dockerbuildbot-index.docker.io")) {
-        wrap([$class: 'TimestamperBuildWrapper']) {
-          wrap([$class: 'AnsiColorBuildWrapper']) {
-            if (vars.get('cleanWorkspace', false)) {
-              // NOTE: `withChownWorkspace` uses docker. if our `label` doesn't have docker
-              // or is misconfigured, these operations will fail and the exception will be
-              // propogated.
-              withChownWorkspace { echo "cleanWorkspace: Ensuring workspace is owned by ${env.USER}" }
-              echo "cleanWorkspace: Removing existing workspace"
-              deleteDir()
-              echo "cleanWorkspace: Workspace is clean."
-            }
-            if (body) { body() }
+    withDockerRegistry(url: vars.get("registryUrl", "https://index.docker.io/v1/"), credentialsId: vars.get("registryCreds", "dockerbuildbot-index.docker.io")) {
+      wrap([$class: 'TimestamperBuildWrapper']) {
+        wrap([$class: 'AnsiColorBuildWrapper']) {
+          if (vars.get('cleanWorkspace', false)) {
+            // NOTE: `withChownWorkspace` uses docker. if our `label` doesn't have docker
+            // or is misconfigured, these operations will fail and the exception will be
+            // propogated.
+            withChownWorkspace { echo "cleanWorkspace: Ensuring workspace is owned by ${env.USER}" }
+            echo "cleanWorkspace: Removing existing workspace"
+            deleteDir()
+            echo "cleanWorkspace: Workspace is clean."
           }
+          if (body) { body() }
         }
       }
     }


### PR DESCRIPTION
at one time, this var was not provided by default (i think because of the github org pipeline plugin? but not sure). Anyway, it's present now in pipelines using the vanilla `node` function, so we can remove it from here.

This also has the nice side effect of making `wrappedNode` usable on windows systems where `sh` doesn't work.

@andrewhsu

(cc @dhiltgen)