### PR TITLE
Delete docker containers if cleanWorkspace is set to true

### DIFF
--- a/vars/wrappedNode.groovy
+++ b/vars/wrappedNode.groovy
@@ -10,7 +10,7 @@ def call(Map vars, Closure body=null) {
             // propogated.
             withChownWorkspace { echo "cleanWorkspace: Ensuring workspace is owned by ${env.USER}" }
             echo "Removing all docker images"
-            sh("docker ps -aq | xargs docker rm -f")
+            sh("for image in \$(docker ps -aq); do docker rm -f \$image; done")
             echo "Docker images have been removed"
 
             echo "cleanWorkspace: Removing existing workspace"

--- a/vars/wrappedNode.groovy
+++ b/vars/wrappedNode.groovy
@@ -9,6 +9,10 @@ def call(Map vars, Closure body=null) {
             // or is misconfigured, these operations will fail and the exception will be
             // propogated.
             withChownWorkspace { echo "cleanWorkspace: Ensuring workspace is owned by ${env.USER}" }
+            echo "Removing all docker images"
+            sh("docker ps -aq | xargs docker rm -f")
+            echo "Docker images have been removed"
+
             echo "cleanWorkspace: Removing existing workspace"
             deleteDir()
             echo "cleanWorkspace: Workspace is clean."

--- a/vars/wrappedNode.groovy
+++ b/vars/wrappedNode.groovy
@@ -9,9 +9,9 @@ def call(Map vars, Closure body=null) {
             // or is misconfigured, these operations will fail and the exception will be
             // propogated.
             withChownWorkspace { echo "cleanWorkspace: Ensuring workspace is owned by ${env.USER}" }
-            echo "Removing all docker images"
-            sh("for image in \$(docker ps -aq); do docker rm -f \$image; done")
-            echo "Docker images have been removed"
+            echo "Removing all docker containers"
+            sh("for cid in \$(docker ls -aq); do docker container rm -vf \$cid; done")
+            echo "Docker containers have been removed"
 
             echo "cleanWorkspace: Removing existing workspace"
             deleteDir()

--- a/vars/wrappedNode.txt
+++ b/vars/wrappedNode.txt
@@ -6,6 +6,6 @@ Runs the given closure on a node matching <code>label</code> with the following 
 <li>Timestamps in build output</li>
 <li>Colored output</li>
 <li>Logged into the Docker Registry with the credentials specified by the given ID</li>
-<li>If cleanWorkspace is true, the workspace is removed (chowning the directory first).</li>
+<li>If cleanWorkspace is true, all containers are removed and the workspace is removed (chowning the directory first).</li>
 </ul>
 </p>


### PR DESCRIPTION
It's possible that this can't delete containers that are part of a service. More specifically the container might be deleted, but the service could bring up additional containers.

If we want to account for this we would have to remove the services first.

Signed-off-by: jose-bigio <jose.bigio@docker.com>